### PR TITLE
fix: anchor the lorebook entry sort menu to its own toolbar row

### DIFF
--- a/src/lib/components/lorebook/LorebookView.svelte
+++ b/src/lib/components/lorebook/LorebookView.svelte
@@ -1096,10 +1096,24 @@
 		padding: 0 0 0.5rem;
 	}
 
+	/* The position context the BrowsePopover panels in this row anchor to, the same job
+	   .brw-bar does for the library toolbars. Without it the panel resolves against an
+	   ancestor further up, lands away from its trigger, and .panel-scroll clips it: the
+	   sort menu renders in full and is never visible. */
 	.lb-controls-row {
+		position: relative;
 		display: flex;
 		align-items: center;
 		gap: 0.375rem;
+	}
+
+	/* And left aligned, not right. BrowsePopover pins its panel to the anchor's right edge,
+	   which suits the library toolbars because their triggers sit at that end. Here Sort is the
+	   leftmost control and New is at the far end of the row, so the default would open the menu
+	   under New: visible, but a whole row away from the button that summoned it. */
+	.lb-controls-row :global(.brw-pop-panel) {
+		right: auto;
+		left: 0;
 	}
 
 	/* Inside the column the bulk bar reads as a banner, not a full-bleed strip. */


### PR DESCRIPTION
Just submitting the PR's for the lorebook fixes, Lorebook Entry Sort button not working

https://github.com/patcireamo/ChungusHub/issues/21

Claude Summary:
Part one of #21: the entry Sort button in the Lorebooks pane looks dead.

The button works and the menu renders in full — it just isn't visible.
`BrowsePopover` positions its panel against the nearest positioned ancestor, and
`.lb-controls-row`, the row the trigger sits in, has no `position`. The panel resolves
against an ancestor further up instead, lands away from the button, and `.panel-scroll`
clips what is left. Adding `position: relative` to that row gives the panel the
containing block it expects, which is the same job `.brw-bar` already does for the
library toolbars.

A second declaration goes with it. `BrowsePopover` pins its panel to the anchor's right
edge, which suits the library toolbars because their triggers sit at that end. In this
row Sort is the leftmost control and New is at the far end, so the right-edge default
opens the menu under New — visible, but a whole row away from the button that summoned
it. The row therefore overrides the panel to `left: 0`.

CSS only; no component or store touched.

### Verification

`bun run check`, `bun test` and `bun run build` all pass on this branch on its own
(1112 tests, 0 failures — the branch adds no tests, it is a 14-line style change).
Run locally on Windows with bun 1.4.0; CI covers the Linux leg and the pinned 1.3.9.