### PR TITLE
fix: read a key listed twice as one key - Triggered lorebook icon on chat message not loading popup

### DIFF
--- a/src/lib/components/lorebook/LorebookTraceList.svelte
+++ b/src/lib/components/lorebook/LorebookTraceList.svelte
@@ -122,7 +122,10 @@
 								</p>
 								{#if record.matches.length > 0}
 									<p class="lt-keys">
-										{#each record.matches as match (match.role + match.key)}
+										<!-- Unkeyed on purpose. The list is built fresh on every render and never
+										     reorders, so a key buys nothing here, and role+key is not a value the
+										     engine can promise is unique. -->
+										{#each record.matches as match}
 											<span class="lt-key" class:lt-key-secondary={match.role === 'secondary'}>
 												{match.key}
 												<span class="lt-where">{sourceLabel(match, record.bookName)}</span>

--- a/src/lib/lorebook/engine.test.ts
+++ b/src/lib/lorebook/engine.test.ts
@@ -325,6 +325,36 @@ describe('per-key matching', () => {
 		expect(resolveKeyMatch('/home/user/', undefined, entryDefaults).mode).toBe('regex');
 		expect(resolveKeyMatch('and/or', undefined, entryDefaults).mode).toBe('word');
 	});
+
+	// A repeat reaches the engine only through an import - SillyTavern's own files carry them
+	// and the list is read verbatim - and it used to be reported once per copy. Two identical
+	// matches are two costs: the trace renders a row per match and cannot key them apart, and
+	// an entry's group score is `matches.length`, which the repeat inflates.
+	test('a key listed twice is reported once', () => {
+		const b = book([{ comment: 'Dupe', content: 'c', key: ['phone', 'phone'] }]);
+		expect(recordFor([b], ['I picked up the phone.'], 'Dupe').matches).toHaveLength(1);
+	});
+
+	test('two different keys matching the same turn are still two matches', () => {
+		const b = book([{ comment: 'Both', content: 'c', key: ['phone', 'telephone'] }]);
+		const match = recordFor([b], ['the telephone is not a phone'], 'Both').matches;
+		expect(match.map((m) => m.key)).toEqual(['phone', 'telephone']);
+	});
+
+	// Compared as written, so this stays two keys: an author writing both spellings, not a
+	// file repeating one. They match the same text under the default case-insensitive rule.
+	test('two spellings of one key differing only in case stay two keys', () => {
+		const b = book([{ comment: 'Case', content: 'c', key: ['Phone', 'phone'] }]);
+		expect(recordFor([b], ['a phone rang'], 'Case').matches.map((m) => m.key)).toEqual(['Phone', 'phone']);
+	});
+
+	test('a repeated key no longer inflates an entry past a rival that matched more', () => {
+		const b = book([
+			{ comment: 'A', content: 'a', key: ['rain', 'rain'], group: 'weather', useGroupScoring: true, order: 100 },
+			{ comment: 'B', content: 'b', key: ['rain', 'storm'], group: 'weather', order: 200 }
+		]);
+		expect(fired([b], ['rain and storm'])).toEqual(['b']);
+	});
 });
 
 describe('scan sources beyond the chat', () => {

--- a/src/lib/lorebook/engine.ts
+++ b/src/lib/lorebook/engine.ts
@@ -224,7 +224,17 @@ function found(
 	defaults: MatchDefaults
 ): LorebookKeyMatch[] {
 	const hits: LorebookKeyMatch[] = [];
+	// A key listed twice is one key. Nobody writes one deliberately - the chip input refuses a
+	// repeat - but SillyTavern's own files carry them and `asKeyList` reads a list verbatim, so
+	// a book can arrive with one and never say so. Evaluated twice it costs two ways: the
+	// entry's group score is `matches.length`, which a repeat inflates past an entry that
+	// genuinely matched more keys, and the trace renders one row per match, keyed by role and
+	// key, which a repeat makes non-unique. Compared as written, so a key that differs only in
+	// case stays two keys: that is an author writing two spellings, not a file repeating one.
+	const seen = new Set<string>();
 	for (const key of keys) {
+		if (seen.has(key)) continue;
+		seen.add(key);
 		const hit = findKey(key, sources, role, rules, defaults);
 		if (hit) hits.push(hit);
 	}


### PR DESCRIPTION
I got curious regarding #72 as i wasn't able to replicate the issue in my own chats, after further discussion, have managed to find the error with was a key duplication.


Claude Summary:
A lorebook entry can hold the same key string more than once. When it does, clicking the
lorebook pill above a reply does nothing at all — the popup never opens, and the console
carries only a bare `https://svelte.dev/e/each_key_duplicate`. This is the symptom reported
in #72.

The scan reported one match per copy of the key, and two identical matches are a duplicate
key in a keyed `{#each}`. Svelte throws there in **production** builds as well as in dev
(`each.js`, the `length > keys.size` branch), with the detail stripped, so the failure is
silent to the reader and near-unreadable in the console.

`found()` in `src/lib/lorebook/engine.ts` now skips a key it has already evaluated.

### Reproducing it

A native World Info file with one entry keyed `["phone", "phone"]`, imported, linked to a
chat, and a turn containing the word *phone*. The pill renders and shows its count; hovering
it highlights; clicking it does nothing. Before this change:

```
matches → [ { role: 'primary', key: 'phone' }, { role: 'primary', key: 'phone' } ]
each key → "primaryphone", "primaryphone"
```

### Where the duplicate comes from

Not from the editor. `KeyChipInput` refuses a repeat, so a key list typed by hand cannot
contain one. It comes from **import**: `asKeyList` in `sillytavern.ts` reads a key list
verbatim, which is the right thing for round-tripping a stranger's book, and SillyTavern's own
World Info files do carry repeats. So a book arrives with one and never says so.

### The repeat cost two things, not one

The popup is the visible half. The other is silent:

- **The trace list** renders one row per match and keys them by role and key, which a repeat
  makes non-unique. That is the crash.
- **Inclusion-group scoring** is `record.matches.length` (`resolveGroups`). A repeat inflated
  an entry's score past a rival that had genuinely matched more *distinct* keys, so the wrong
  entry won its group — quietly, and in a way no trace would have explained, because both
  copies read identically in the popup that could not open.

The second is why this is fixed in the engine rather than in the component.

### Compared as written, deliberately

The dedupe compares key strings byte for byte, so `Phone` and `phone` stay **two keys**. They
match the same text under the default case-insensitive rule, so folding them looks tempting —
but an entry can be set case-sensitive, per entry or per key, and there the two are genuinely
different keys doing different jobs. Folding would silently delete one of them. A repeat that
is byte-identical is the only one that is certainly meaningless, and it is the only one
removed. There is a test for each side of that line.

### What is deliberately not done

**Existing books are not rewritten.** No cull on import, no sweep. After this change a
repeated key is completely inert — it cannot crash the trace, cannot inflate a score, cannot
change what matches — so culling it would buy nothing and would cost the round-trip fidelity
`sillytavern.ts` is built for: an imported book exports again unchanged, and silently editing
a modelled field on the way in breaks that.

### The keyed each

`LorebookTraceList.svelte` drops the key on that block as well. The list is rebuilt on every
render and never reorders, so the key bought nothing, and `role + key` is not a value the
engine can promise is unique. Belt and braces rather than the fix itself — with the engine
change in place, the block cannot be handed a duplicate.

### One thing I cannot claim

This reproduces #72's symptom exactly, but I have not seen the reporter's book, so I cannot
say with certainty that a repeated key is *their* cause. The console error names it in one
line if anyone wants to confirm before merging.

### No migration

No stored shape changes. `found()` is a read-time filter over a key list that is already on
disk, so nothing is written, nothing is upgraded, and an entry with a repeated key keeps it —
it is simply read once. No schema change, no new setting.

### Verification

Measured on `fix/duplicate-lore-keys` @ f9cb486, on `main` @ be8eda1, 2026-09-11.
bun 1.4.0 locally (CI pins 1.3.9).

- `bun run check` — **0 errors, 0 warnings**
- `bun test` — **1527 pass, 0 fail**, 6257 expect() calls across 86 files
  - 4 of those tests are new on this branch
- `bun run build` — succeeds

**Added:** 4 tests in `engine.test.ts`. Two fail without the engine change — a repeated key
reported once, and a repeated key no longer outscoring a rival that matched more distinct
keys. The other two pass on both sides on purpose, pinning the line the dedupe must not cross:
`phone` + `telephone` matching one turn stay two matches, and `Phone` + `phone` stay two keys.

**No coverage:** the trace popup's markup. This repo has no component-test harness, and adding
one is not this PR's job. The crash and the fix were both driven by hand in a production
build, against an imported book with a repeated key.

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)

